### PR TITLE
Reload gcloud configuration after failure

### DIFF
--- a/Plugin.Google.CloudIap/Gui/Plugin.cs
+++ b/Plugin.Google.CloudIap/Gui/Plugin.cs
@@ -21,6 +21,7 @@
 
 using Plugin.Google.CloudIap.Configuration;
 using Plugin.Google.CloudIap.Integration;
+using Plugin.Google.CloudIap.Util;
 using RdcMan;
 using System;
 using System.Collections.Generic;
@@ -48,7 +49,7 @@ namespace Plugin.Google.CloudIap.Gui
         private readonly PluginConfiguration configuration;
         private readonly IapTunnelManager tunnelManager;
         private readonly WindowsPasswordManager windowsPasswordManager;
-        private readonly Lazy<ProjectCollection> projects = new Lazy<ProjectCollection>(
+        private readonly LazyWithRetry<ProjectCollection> projects = new LazyWithRetry<ProjectCollection>(
             () => new ProjectCollection(ComputeEngineAdapter.Create(GcloudAccountConfiguration.ActiveAccount.Credential)));
 
         private Form mainForm = null;

--- a/Plugin.Google.CloudIap/Integration/Project.cs
+++ b/Plugin.Google.CloudIap/Integration/Project.cs
@@ -33,7 +33,6 @@ namespace Plugin.Google.CloudIap.Integration
     internal class Project
     {
         private readonly string projectId;
-        private readonly IEnumerable<string> zones;
         private readonly ComputeEngineAdapter adapter;
 
         public Project(string projectId, IEnumerable<string> zones, ComputeEngineAdapter adapter)

--- a/Plugin.Google.CloudIap/Plugin.Google.CloudIap.csproj
+++ b/Plugin.Google.CloudIap/Plugin.Google.CloudIap.csproj
@@ -135,6 +135,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Util\LazyWithRetry.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Plugin.Google.CloudIap/Util/LazyWithRetry.cs
+++ b/Plugin.Google.CloudIap/Util/LazyWithRetry.cs
@@ -1,8 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿//
+// Copyright 2019 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using System;
 
 namespace Plugin.Google.CloudIap.Util
 {

--- a/Plugin.Google.CloudIap/Util/LazyWithRetry.cs
+++ b/Plugin.Google.CloudIap/Util/LazyWithRetry.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Plugin.Google.CloudIap.Util
+{
+    public class LazyWithRetry<T> where T : class
+    {
+        private readonly Func<T> valueFactory;
+        private readonly object instanceLock = new object();
+        private T instance;
+
+        public LazyWithRetry(Func<T> valueFactory)
+        {
+            this.valueFactory = valueFactory;
+            this.instance = null;
+        }
+
+        public T Value
+        {
+            get
+            {
+                lock (instanceLock)
+                {
+                    if (this.instance == null)
+                    {
+                        // Create new instance. If it throws an exception, we will
+                        // simply retry next time. System.Lazy, in contrast, would
+                        // cache and rethrow an exception in this case.
+                        this.instance = this.valueFactory();
+                    }
+
+                    return this.instance;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
If no valid gcloud configuration can be found, do not cache
the failure so that the user can run "gcloud auth login" and
retry the operation without having to restart RDCMan.