### PR TITLE
Improve error handling for credential generation

### DIFF
--- a/Google.Solutions.Compute/Extensions/AddMetadata.cs
+++ b/Google.Solutions.Compute/Extensions/AddMetadata.cs
@@ -52,6 +52,30 @@ namespace Google.Solutions.Compute.Extensions
         }
 
         /// <summary>
+        /// Query a metadata entry for an instance.
+        /// </summary>
+        /// <returns>null if not set/found</returns>
+        public static async Task<Metadata.ItemsData> QueryMetadataKeyAsync(
+            this InstancesResource resource,
+            VmInstanceReference instanceRef,
+            string key)
+        {
+            var instance = await resource.Get(
+                instanceRef.ProjectId,
+                instanceRef.Zone,
+                instanceRef.InstanceName).ExecuteAsync().ConfigureAwait(false);
+
+            if (instance.Metadata == null || instance.Metadata.Items == null)
+            {
+                return null;
+            }
+
+            return instance.Metadata.Items
+                .Where(i => i.Key == key)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
         /// Adds or overwrites a metadata key/value pair to a GCE 
         /// instance. Any existing metadata is kept as is.
         /// </summary>


### PR DESCRIPTION
When the user lacks the 'Service Account User' role,
password generation might fail.

Add error handling to detect this error more quickly and
show proper error message.

Change-Id: Ifed041137c10534aa634c5a2509d086c56fbc33b