### PR TITLE
Properly filter instances that have disks without licenses

### DIFF
--- a/Google.Solutions.CloudIap.Plugin/Integration/ComputeEngineAdapter.cs
+++ b/Google.Solutions.CloudIap.Plugin/Integration/ComputeEngineAdapter.cs
@@ -158,6 +158,7 @@ namespace Google.Solutions.CloudIap.Plugin.Integration
             // has to have an associated Windows license. This is also true for
             // BYOL'ed instances.
             return instance.Disks
+                .Where(d => d.Licenses != null)
                 .SelectMany(d => d.Licenses)
                 .Any(l => l.StartsWith(WindowsCloudLicenses));
         }


### PR DESCRIPTION
This is to fix https://github.com/GoogleCloudPlatform/iap-windows-rdc-plugin/issues/22