### PR TITLE
Use 'next' positions for serial port logging

### DIFF
--- a/Google.Solutions.Compute.Test/Extensions/TestGetSerialPortOutputStream.cs
+++ b/Google.Solutions.Compute.Test/Extensions/TestGetSerialPortOutputStream.cs
@@ -1,0 +1,49 @@
+﻿
+using Google.Solutions.Compute.Test.Env;
+using Google.Solutions.Compute.Extensions;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+using Google.Apis.Compute.v1;
+
+namespace Google.Solutions.Compute.Test.Extensions
+{
+    [TestFixture]
+    [Category("IntegrationTest")]
+    [Category("Windows")]
+    public class TestGetSerialPortOutputStream
+    {
+        private InstancesResource instancesResource;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.instancesResource = ComputeEngine.Connect().Service.Instances;
+        }
+
+        [Test]
+        public async Task TestResetPasswordForSuperLongUsernameFails(
+           [WindowsInstance] InstanceRequest testInstance)
+        {
+            await testInstance.AwaitReady();
+
+            var stream = this.instancesResource.GetSerialPortOutputStream(
+                testInstance.InstanceReference, 
+                1);
+
+            var startTime = DateTime.Now;
+            
+            while (DateTime.Now < startTime.AddMinutes(3))
+            {
+                var log = await stream.ReadAsync();
+                if (log.Contains("Instance setup finished"))
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail("Timeout waiting for serial console output to appear");
+        }
+
+    }
+}

--- a/Google.Solutions.Compute.Test/Google.Solutions.Compute.Test.csproj
+++ b/Google.Solutions.Compute.Test/Google.Solutions.Compute.Test.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Env\ComputeEngine.cs" />
     <Compile Include="Env\Defaults.cs" />
     <Compile Include="Env\InstanceAttribute.cs" />
+    <Compile Include="Extensions\TestGetSerialPortOutputStream.cs" />
     <Compile Include="Extensions\TestResetWindowsUser.cs" />
     <Compile Include="FixtureBase.cs" />
     <Compile Include="IapClient\TestCommandLine.cs" />


### PR DESCRIPTION
Use start/next offsets of REST API to stitch the stream together.