### PR TITLE
Ignore unrecognized message tags

### DIFF
--- a/Google.Solutions.CloudIap.Plugin/Integration/DefaultTunnelingManager.cs
+++ b/Google.Solutions.CloudIap.Plugin/Integration/DefaultTunnelingManager.cs
@@ -36,7 +36,7 @@ namespace Google.Solutions.CloudIap.Plugin.Integration
             this.credential = credential;
         }
 
-        protected async override Task<ITunnel> CreateTunnelAsync(
+        protected override Task<ITunnel> CreateTunnelAsync(
             TunnelDestination tunnelEndpoint, 
             TimeSpan timeout)
         {
@@ -57,7 +57,7 @@ namespace Google.Solutions.CloudIap.Plugin.Integration
 
             // Return the tunnel which allows the listener to be stopped
             // via the CancellationTokenSource.
-            return new Tunnel(iapEndpoint, listener, cts);
+            return Task.FromResult<ITunnel>(new Tunnel(iapEndpoint, listener, cts));
         }
 
         internal class Tunnel : ITunnel

--- a/Google.Solutions.Compute/Iap/SshRelayStream.cs
+++ b/Google.Solutions.Compute/Iap/SshRelayStream.cs
@@ -345,7 +345,19 @@ namespace Google.Solutions.Compute.Iap
                             }
 
                         default:
-                            throw new InvalidServerResponseException($"Unknown tag: {tag}");
+                            if (this.Sid == null)
+                            {
+                                // An unrecognized tag at the start of a connection means that we are
+                                // essentially reading junk, so bail out.
+                                throw new InvalidServerResponseException($"Unknown tag: {tag}");
+                            }
+                            else
+                            {
+                                // The connection was properly opened - an unrecognized tag merely
+                                // means that the server uses a feature that we do not support (yet).
+                                // In accordance with the protocol specification, ignore this tag.
+                                break;
+                            }
                     }
                 }
                 catch (WebSocketStreamClosedByClientException)


### PR DESCRIPTION
Ignore unrecognized tags to future-proof the implementation.
Newer versions of the protocol might introduce new message tags
which should not cause the implementation to break.