### PR TITLE
Derive username from email address

### DIFF
--- a/Google.Solutions.IapDesktop.Application.Test/Google.Solutions.IapDesktop.Application.Test.csproj
+++ b/Google.Solutions.IapDesktop.Application.Test/Google.Solutions.IapDesktop.Application.Test.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Settings\TestInventorySettingsRepository.cs" />
     <Compile Include="ServiceModel\TestServiceRegistry.cs" />
     <Compile Include="TestExceptionExtensions.cs" />
+    <Compile Include="Util\TestAuthorizationExtensions.cs" />
     <Compile Include="Windows\TestMainForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Google.Solutions.IapDesktop.Application.Test/Util/TestAuthorizationExtensions.cs
+++ b/Google.Solutions.IapDesktop.Application.Test/Util/TestAuthorizationExtensions.cs
@@ -1,0 +1,66 @@
+﻿//
+// Copyright 2020 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Compute.Auth;
+using Google.Solutions.IapDesktop.Application.Util;
+using Moq;
+using NUnit.Framework;
+using System;
+
+namespace Google.Solutions.IapDesktop.Application.Test.Util
+{
+    [TestFixture]
+    public class TestAuthorizationExtensions
+    {
+        [Test]
+        public void WhenAuthorizationEmailIsNull_ThenSuggestWindowsUsernameReturnsWindowsUsername()
+        {
+            var authorization = new Mock<IAuthorization>();
+            authorization.SetupGet(a => a.Email).Returns((string)null);
+
+            var suggestedUsername = authorization.Object.SuggestWindowsUsername();
+
+            Assert.AreEqual(Environment.UserName, suggestedUsername);
+        }
+
+        [Test]
+        public void WhenAuthorizationHasInvalidEmail_ThenSuggestWindowsUsernameReturnsWindowsUsername()
+        {
+            var authorization = new Mock<IAuthorization>();
+            authorization.SetupGet(a => a.Email).Returns("joe");
+
+            var suggestedUsername = authorization.Object.SuggestWindowsUsername();
+
+            Assert.AreEqual(Environment.UserName, suggestedUsername);
+        }
+
+        [Test]
+        public void WhenAuthorizationHasValidEmail_ThenSuggestWindowsUsernameReturnsUserPartOfEmail()
+        {
+            var authorization = new Mock<IAuthorization>();
+            authorization.SetupGet(a => a.Email).Returns("joe@example.com");
+
+            var suggestedUsername = authorization.Object.SuggestWindowsUsername();
+
+            Assert.AreEqual("joe", suggestedUsername);
+        }
+    }
+}

--- a/Google.Solutions.IapDesktop.Application/Google.Solutions.IapDesktop.Application.csproj
+++ b/Google.Solutions.IapDesktop.Application/Google.Solutions.IapDesktop.Application.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Registry\RegistryValueAttribute.cs" />
     <Compile Include="Settings\InventorySettingsRepository.cs" />
     <Compile Include="TraceSources.cs" />
+    <Compile Include="Util\AuthorizationExtensions.cs" />
     <Compile Include="Windows\AboutWindow.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -301,9 +302,7 @@
   <ItemGroup>
     <None Include="Resources\Refresh_161.png" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Util\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\MSBuild.AssemblyVersion.1.2.0\build\MSBuild.AssemblyVersion.targets" Condition="Exists('..\packages\MSBuild.AssemblyVersion.1.2.0\build\MSBuild.AssemblyVersion.targets')" />
 </Project>

--- a/Google.Solutions.IapDesktop.Application/Util/AuthorizationExtensions.cs
+++ b/Google.Solutions.IapDesktop.Application/Util/AuthorizationExtensions.cs
@@ -1,0 +1,47 @@
+﻿//
+// Copyright 2020 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Compute.Auth;
+using System;
+using System.Diagnostics;
+
+namespace Google.Solutions.IapDesktop.Application.Util
+{
+    internal static class AuthorizationExtensions
+    {
+        public static string SuggestWindowsUsername(this IAuthorization authorization)
+        {
+            var email = authorization.Email;
+
+            int atIndex;
+            if (!string.IsNullOrEmpty(email) && (atIndex = email.IndexOf('@')) > 0)
+            {
+                return email.Substring(0, atIndex);
+            }
+            else
+            {
+                // Such an email should never surface, but revert
+                // to using the local Windows username then.
+                return Environment.UserName;
+            }
+        }
+    }
+}

--- a/Google.Solutions.IapDesktop.Application/Windows/ProjectExplorer/ProjectExplorerWindow.cs
+++ b/Google.Solutions.IapDesktop.Application/Windows/ProjectExplorer/ProjectExplorerWindow.cs
@@ -31,6 +31,7 @@ using Google.Solutions.IapDesktop.Application.SettingsEditor;
 using Google.Solutions.IapDesktop.Application.Windows;
 using Google.Solutions.IapDesktop.Application.Windows.RemoteDesktop;
 using Google.Solutions.IapDesktop.Application.Windows.SerialLog;
+using Google.Solutions.IapDesktop.Application.Util;
 using Google.Solutions.IapDesktop.Windows;
 using System;
 using System.Collections.Generic;
@@ -154,8 +155,7 @@ namespace Google.Solutions.IapDesktop.Application.ProjectExplorer
 
         private async Task GenerateCredentials(VmInstanceNode vmNode)
         {
-            // Derive a suggested username from the Windows login name.
-            var suggestedUsername = Environment.UserName;
+            var suggestedUsername = this.authService.Authorization.SuggestWindowsUsername();
 
             // Prompt for username to use.
             var username = new GenerateCredentialsDialog().PromptForUsername(this, suggestedUsername);


### PR DESCRIPTION
Derive the suggested Windows username from the email address
used for signing in. This aligns the behavior with the
Cloud Console's behavior.