### PR TITLE
Embed job type in machine hash

### DIFF
--- a/Google.Solutions.Compute.Test/Env/InstanceAttribute.cs
+++ b/Google.Solutions.Compute.Test/Env/InstanceAttribute.cs
@@ -77,6 +77,13 @@ namespace Google.Solutions.Compute.Test.Env
                 imageSpecification.Append(this.ImageFamily);
                 imageSpecification.Append(this.InitializeScript);
 
+                var kokoroJobType = Environment.GetEnvironmentVariable("KOKORO_JOB_TYPE");
+                if (!string.IsNullOrEmpty(kokoroJobType))
+                {
+                    // Prevent different job types sharing the same VMs.
+                    imageSpecification.Append(kokoroJobType);
+                }
+
                 using (var sha = new System.Security.Cryptography.SHA256Managed())
                 {
                     var imageSpecificationRaw = Encoding.UTF8.GetBytes(imageSpecification.ToString());


### PR DESCRIPTION
Embed Kokoro job type in machine hash/VM name so that different types of jobs do not share the same VMs.