### PR TITLE
Hide Minimize button in full-screen mode

### DIFF
--- a/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RemoteDesktopPane.Designer.cs
+++ b/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RemoteDesktopPane.Designer.cs
@@ -77,6 +77,7 @@ namespace Google.Solutions.IapDesktop.Application.Services.Windows.RemoteDesktop
             this.rdpClient.OnAuthenticationWarningDisplayed += new System.EventHandler(this.rdpClient_OnAuthenticationWarningDisplayed);
             this.rdpClient.OnLogonError += new AxMSTSCLib.IMsTscAxEvents_OnLogonErrorEventHandler(this.rdpClient_OnLogonError);
             this.rdpClient.OnFocusReleased += new AxMSTSCLib.IMsTscAxEvents_OnFocusReleasedEventHandler(this.rdpClient_OnFocusReleased);
+            this.rdpClient.OnServiceMessageReceived += new AxMSTSCLib.IMsTscAxEvents_OnServiceMessageReceivedEventHandler(this.rdpClient_OnServiceMessageReceived);
             this.rdpClient.OnAutoReconnected += new System.EventHandler(this.rdpClient_OnAutoReconnected);
             this.rdpClient.OnAutoReconnecting2 += new AxMSTSCLib.IMsTscAxEvents_OnAutoReconnecting2EventHandler(this.rdpClient_OnAutoReconnecting2);
             // 

--- a/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RemoteDesktopPane.cs
+++ b/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RemoteDesktopPane.cs
@@ -173,6 +173,7 @@ namespace Google.Solutions.IapDesktop.Application.Services.Windows.RemoteDesktop
                 //
                 advancedSettings.DisplayConnectionBar =
                     (settings.ConnectionBar != RdpConnectionBarState.Off);
+                advancedSettings.ConnectionBarShowMinimizeButton = false;
                 advancedSettings.PinConnectionBar =
                     (settings.ConnectionBar == RdpConnectionBarState.Pinned);
                 advancedSettings.EnableWindowsKey = 1;
@@ -517,6 +518,14 @@ namespace Google.Solutions.IapDesktop.Application.Services.Windows.RemoteDesktop
             IMsTscAxEvents_OnRemoteDesktopSizeChangeEvent e)
         {
             using (TraceSources.IapDesktop.TraceMethod().WithParameters(this.autoResize))
+            { }
+        }
+
+        private void rdpClient_OnServiceMessageReceived(
+            object sender,
+            IMsTscAxEvents_OnServiceMessageReceivedEvent e)
+        {
+            using (TraceSources.IapDesktop.TraceMethod().WithParameters(e.serviceMessage))
             { }
         }
 


### PR DESCRIPTION
If the user minimizes from within full-screen mode, the control does not send any events that could be used to prevent the "white screen" issue. 

As the events of minimizing are unclear in case of a multi-RDP app anyway, the easiest solution is to hide the button.

This is to fix #87.